### PR TITLE
Fix to `option go_package` into `code/pix/application/grpc/protofiles/pixkey.proto`

### DIFF
--- a/codepix/application/grpc/protofiles/pixkey.proto
+++ b/codepix/application/grpc/protofiles/pixkey.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package github.com.codeedu.codepix;
 
-option go_package = "protofiles;pb";
+option go_package = "protofiles/pb";
 
 message PixKeyRegistration {
     string kind = 1;


### PR DESCRIPTION
Fix to `option go_package` into `code/pix/application/grpc/protofiles/pixkey.proto`

Error: The import path must contain at least one period ('.') or forward slash ('/') character.

I Also answered for me at the comments of this movie: https://www.youtube.com/watch?v=DP9zfx-7ChA

Issue related: https://github.com/codeedu/imersao-7-codepix/issues/3